### PR TITLE
bugfix: typo in StochasticOutlierDetection.performOutlierDetection 

### DIFF
--- a/src/main/scala/frl/driesprong/outlierdectection/StochasticOutlierDetection.scala
+++ b/src/main/scala/frl/driesprong/outlierdectection/StochasticOutlierDetection.scala
@@ -13,7 +13,7 @@ object StochasticOutlierDetection {
 
   def performOutlierDetection(inputVectors: RDD[(Long, Array[Double])],
                               perplexity: Double = DefaultPerplexity,
-                              tolerance: Double = DefaultPerplexity,
+                              tolerance: Double = DefaultTolerance,
                               maxIterations: Int = DefaultIterations ): Array[(Long, Double)] = {
 
     val dMatrix = StochasticOutlierDetection.computeDistanceMatrixPair(inputVectors)


### PR DESCRIPTION
Use `DefaultTolerance` for `tolerance` instead of `DefaultPerplexity` as default value.

Fix for #2 