### PR TITLE
fix: using local[*] leads to wrong results

### DIFF
--- a/src/main/scala/frl/driesprong/outlierdectection/EvaluateOutlierDetection.scala
+++ b/src/main/scala/frl/driesprong/outlierdectection/EvaluateOutlierDetection.scala
@@ -6,7 +6,7 @@ object EvaluateOutlierDetection {
 
   def main(args: Array[String]) {
     val conf = new SparkConf()
-      .setMaster("local[*]")
+      .setMaster("local")
       .setAppName("Stochastic Outlier Selection")
 
     val sc = new SparkContext(conf)


### PR DESCRIPTION
Changing Spark master from `local[*]` to `local` - parallelism seems to lead to wrong results in outlier probability computation.

Fix for #4 